### PR TITLE
Fix squashing in CentOS

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -36,7 +36,10 @@ function docker_build_with_version {
   cp ${DOCKERFILE_PATH} "${DOCKERFILE_PATH}.version"
   git_version=$(git rev-parse --short HEAD)
   echo "LABEL io.openshift.builder-version=\"${git_version}\"" >> "${dockerfile}.version"
-  docker build -t ${IMAGE_NAME} -f "${dockerfile}.version" .
+  if [[ "${UPDATE_BASE}" == "1" ]]; then
+    BUILD_OPTIONS+=" --pull=true"
+  fi
+  docker build ${BUILD_OPTIONS} -t ${IMAGE_NAME} -f "${dockerfile}.version" .
   if [[ "${SKIP_SQUASH}" != "1" ]]; then
     squash "${dockerfile}.version"
   fi

--- a/hack/common.mk
+++ b/hack/common.mk
@@ -10,6 +10,7 @@ endif
 
 script_env = \
 	SKIP_SQUASH=$(SKIP_SQUASH)                      \
+	UPDATE_BASE=$(UPDATE_BASE)                      \
 	VERSIONS="$(VERSIONS)"                          \
 	OS=$(OS)                                        \
 	VERSION=$(VERSION)                              \


### PR DESCRIPTION
Docker-squash requires docker_py >= 1.7.2, so "easy_install -q --user docker_py==1.6.0 docker-squash==1.0.0rc6" resolves to install latest docker_py version which requires new setuptools with environment markers support. So this command success in CentOS only with latest rh-python35.

Also updated to use latest docker-squash.

@hhorak @bparees Please test. This PR is same as sclorg/mariadb-container#9